### PR TITLE
Modify scale calculation to make outer padding consistent when count =1 as well.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "d3-format": "1",
     "d3-interpolate": "1",
     "vega-dataflow": ">=2.0.0-beta.4",
-    "vega-scale": "1",
+    "vega-scale": ">=1.1",
     "vega-util": "1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-encode",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Visual encoding transforms for Vega dataflows.",
   "keywords": [
     "vega",

--- a/src/Scale.js
+++ b/src/Scale.js
@@ -105,14 +105,16 @@ function configureRange(scale, _, count) {
     }
 
     // calculate full range based on requested step size and padding
-    // Mirrors https://github.com/d3/d3-scale/blob/master/src/band.js#L23
-    //  step = span / (n ? n - paddingInner + paddingOuter * 2 : 1)
-    // with an exception that for count = 0, we set space = 0 so that range is [0,0]
-    // to avoid drawing empty ordinal axis.
+    // Mirrors https://github.com/vega/vega-scale/blob/master/src/band.js#L23
+    //   space = n - paddingInner + paddingOuter * 2;
+    //   step = (stop - start) / (space > 0 ? space : 1);
+    // with an exception that the formula above replaces space with 1 when space is <= 0
+    // to avoid division by zero. Here, we do not have the division by zero problem.
+    // Thus we can set space = 0 to make range = [0,0] to avoid drawing empty ordinal axis.
     var inner = (_.paddingInner != null ? _.paddingInner : _.padding) || 0,
         outer = (_.paddingOuter != null ? _.paddingOuter : _.padding) || 0,
-        space = count ? count - inner + outer * 2 : 0;
-    range = [0, _.rangeStep * space];
+        space = count - inner + outer * 2;
+    range = [0, _.rangeStep * (space > 0 ? space : 0)];
   }
 
   if (range) {

--- a/src/Scale.js
+++ b/src/Scale.js
@@ -1,5 +1,5 @@
 import {Transform} from 'vega-dataflow';
-import {scale as getScale} from 'vega-scale';
+import {scale as getScale, bandSpace} from 'vega-scale';
 import {error, inherits, isFunction, toSet} from 'vega-util';
 import {interpolate, interpolateRound} from 'd3-interpolate';
 
@@ -112,9 +112,8 @@ function configureRange(scale, _, count) {
     // to avoid division by zero. Here, we do not have the division by zero problem.
     // Thus we can set space = 0 to make range = [0,0] to avoid drawing empty ordinal axis.
     var inner = (_.paddingInner != null ? _.paddingInner : _.padding) || 0,
-        outer = (_.paddingOuter != null ? _.paddingOuter : _.padding) || 0,
-        space = count - inner + outer * 2;
-    range = [0, _.rangeStep * (space > 0 ? space : 0)];
+        outer = (_.paddingOuter != null ? _.paddingOuter : _.padding) || 0;
+    range = [0, _.rangeStep * bandSpace(count, inner, outer)];
   }
 
   if (range) {

--- a/src/Scale.js
+++ b/src/Scale.js
@@ -103,12 +103,15 @@ function configureRange(scale, _, count) {
     if (type !== 'band' && type !== 'point') {
       error('Only band and point scales support rangeStep.');
     }
+
     // calculate full range based on requested step size and padding
     // Mirrors https://github.com/d3/d3-scale/blob/master/src/band.js#L23
-    //  step = span / Math.max(1, n - paddingInner + paddingOuter * 2)
+    //  step = span / (n ? n - paddingInner + paddingOuter * 2 : 1)
+    // with an exception that for count = 0, we set space = 0 so that range is [0,0]
+    // to avoid drawing empty ordinal axis.
     var inner = (_.paddingInner != null ? _.paddingInner : _.padding) || 0,
         outer = (_.paddingOuter != null ? _.paddingOuter : _.padding) || 0,
-        space = count ? Math.max(1, count - inner + outer * 2) : 0;
+        space = count ? count - inner + outer * 2 : 0;
     range = [0, _.rangeStep * space];
   }
 


### PR DESCRIPTION
Removing the `max(1, ...)` case here and in vega-scale make outer padding consistent as commented in #1751.

(This depends on https://github.com/vega/vega-scale/pull/1)