### PR TITLE
Make vega-encode depends on vega-scale 2.1 or upper

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "d3-format": "1",
     "d3-interpolate": "1",
     "vega-dataflow": "3",
-    "vega-scale": "2",
+    "vega-scale": "^2.1",
     "vega-util": "1"
   },
   "devDependencies": {


### PR DESCRIPTION
Otherwise compiling Vega and Vega-encode in dependent projects may get the following warnings

```
WARNING in ./~/vega-encode/src/ticks.js
24:36-48 "export 'timeInterval' was not found in 'vega-scale'

WARNING in ./~/vega-encode/src/ticks.js
25:31-42 "export 'utcInterval' was not found in 'vega-scale'
```