### PR TITLE
v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-encode",
-  "version": "2.0.8",
+  "version": "3.0.0",
   "description": "Visual encoding transforms for Vega dataflows.",
   "keywords": [
     "vega",
@@ -28,18 +28,18 @@
     "postpublish": "git push && git push --tags && zip -j build/vega-encode.zip -- LICENSE README.md build/vega-encode.js build/vega-encode.min.js"
   },
   "dependencies": {
-    "d3-array": "1",
-    "d3-format": "1",
-    "d3-interpolate": "1",
-    "vega-dataflow": "3",
-    "vega-scale": "^2.1",
-    "vega-util": "1"
+    "d3-array": "^1.2.1",
+    "d3-format": "^1.2.2",
+    "d3-interpolate": "^1.1.6",
+    "vega-dataflow": "^4.0.0",
+    "vega-scale": "^2.1.1",
+    "vega-util": "^1.7.0"
   },
   "devDependencies": {
     "eslint": "4",
-    "rollup": "0.43",
+    "rollup": "0.58.2",
     "tape": "4",
     "uglify-js": "3",
-    "vega-transforms": "1"
+    "vega-transforms": "^2.0.0"
   }
 }

--- a/src/Scale.js
+++ b/src/Scale.js
@@ -229,7 +229,7 @@ function flip(array, reverse) {
 
 function quantize(interpolator, count) {
   var samples = new Array(count),
-      n = (count - 1) || 1;
-  for (var i = 0; i < count; ++i) samples[i] = interpolator(i / n);
+      n = count + 2;
+  for (var i = 0; i < count;) samples[i] = interpolator(++i / n);
   return samples;
 }

--- a/src/legend-types.js
+++ b/src/legend-types.js
@@ -1,0 +1,3 @@
+export var Symbols  = 'symbol';
+export var Discrete = 'discrete';
+export var Gradient = 'gradient';

--- a/src/ticks.js
+++ b/src/ticks.js
@@ -94,8 +94,8 @@ export function tickValues(scale, count) {
  * @return {function(*):string} - The generated label formatter.
  */
 export function tickFormat(scale, count, specifier) {
-  var format = scale.tickFormat
-    ? scale.tickFormat(count, specifier)
+  var format = scale.tickFormat ? scale.tickFormat(count, specifier)
+    : specifier ? numberFormat(specifier)
     : String;
 
   return (scale.type === Log)


### PR DESCRIPTION
Changes:
- Remove `total` property from generated symbol legend entries.
- Add support for discrete gradient legends.
- Modify colormap quantization for better balance.
- Fix: use provided number format specifier even when scale.tickFormat is undefined.
- Update dependencies, use [vega-dataflow 4.0.0](https://github.com/vega/vega-dataflow/releases/tag/v4.0.0).
